### PR TITLE
Add variable to select an existing secret for tls

### DIFF
--- a/chart/inlets-pro/templates/_helpers.tpl
+++ b/chart/inlets-pro/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the tls to use
+*/}}
+{{- define "inlets-pro.tlsSecretName" -}}
+{{- if .Values.ingress.secretName }}
+{{- .Values.ingress.secretName }}
+{{- else }}
+{{- .Values.ingress.domain }}-tls-secret
+{{- end }}
+{{- end }}

--- a/chart/inlets-pro/templates/ingress.yaml
+++ b/chart/inlets-pro/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "inlets-pro.fullname" . -}}
+{{- $tlsSecretName := include "inlets-pro.tlsSecretName" . -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -17,7 +18,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.domain }}
-      secretName: {{ .Values.ingress.domain }}-tls-secret
+      secretName: {{ $tlsSecretName }}
   rules:
     - host: {{ .Values.ingress.domain }}
       http:


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

By default, the Helm chart adds annotations on the ingress to let the cert-manager issue a certificate and put the result in a secret with a name based on the domain.

This PR adds the possibility to point to an existing TLS secret, e.g. a secret created cert-manager containing a wildcard certificate.