### PR TITLE
Fix Broken Link: charts->chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The inlets-pro binary can be obtained as a stand-alone executable, or via a Dock
 
     Run ad-hoc clients and servers on your Kubernetes clusters
 
-    See [charts](charts) for the inlets-pro TCP client and server
+    See [chart](chart) for the inlets-pro TCP client and server
 
 * Sample Kubernetes YAML files
 


### PR DESCRIPTION
The link in the README is broken, it has a stray (s)