### PR TITLE
Update to agree with the result of arkade (amending with DCO)

### DIFF
--- a/artifacts/client-with-secrets.yaml
+++ b/artifacts/client-with-secrets.yaml
@@ -4,7 +4,7 @@
 
 ## It uses secrets that are mounted into the Pod for the token and the license
 
-# kubectl create secret generic inlets-server-token --from-literal inlets-server-token=$TOKEN
+# kubectl create secret generic inlets-access-key --from-literal inlets-access-key=$TOKEN
 # kubectl create secret generic inlets-license --from-file inlets-license=$HOME/.inlets/LICENSE
 
 # Change SEVER_IP_HERE
@@ -31,9 +31,9 @@ spec:
       - name: inlets-license
         secret:
           secretName: inlets-license
-      - name: inlets-server-token
+      - name: inlets-access-key
         secret:
-          secretName: inlets-server-token
+          secretName: inlets-access-key
       containers:
       - name: inlets-client
         image: ghcr.io/inlets/inlets-pro:0.9.1
@@ -43,12 +43,12 @@ spec:
         - "http"
         - "client"
         - "--url=wss://SERVER_IP_HERE:8123"
-        - "--token-file=/var/secrets/inlets-server-token/inlets-server-token"
+        - "--token-file=/var/secrets/inlets-access-key/inlets-access-key"
         - "--license-file=/var/secrets/inlets-license/inlets-license"
         - "--upstream=http://prometheus.openfaas:9090"
         volumeMounts:
-          - mountPath: /var/secrets/inlets-server-token
-            name: inlets-server-token
+          - mountPath: /var/secrets/inlets-access-key
+            name: inlets-access-key
           - mountPath: /var/secrets/inlets-license
             name: inlets-license
 


### PR DESCRIPTION
Update to agree with the result of arkade

When you `ark install inlets-operator` the operator is placed in the `default` namespace and the server token is called: inlets-access-key

an alternative would be to change the arkade installer to use `inlets-server-token` for the secret name

Signed-off-by: blaisep <blaise@gmail.com>