### PR TITLE
Migrate to v1 of Ingress

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -1,20 +1,22 @@
-## Helm charts for inlets PRO
+## Helm charts for inlets Pro
 
-[inlets PRO](https://inlets.dev/) consists of a client and a server portion.
+[inlets](https://inlets.dev/) consists of a client and a server portion.
 
 When a client wants to expose a service publicly, or privately within a remote network, it connects to a server using its control-plane (a HTTPS websocket).
 
 There is no need for your data plane to be exposed on the Internet, you can bind to a local LAN adapter, or a private ClusterIP. If you do want to expose your tunnelled services to the Internet, you can do with a NodePort, LoadBalancer or through Ingress.
 
-### Deploy an inlets PRO TCP server
+Kubernetes v1.19+ is required for the helm charts provided in this repository, due to the various versions of the Ingress API, the minimum supported version will be `networking.k8s.io/v1`.
+
+### Deploy an inlets Pro TCP server
 
 * [Use your Kubernetes cluster for exit-servers](https://github.com/inlets/inlets-pro/tree/master/chart/inlets-pro)
 
-### Deploy an inlets PRO TCP client
+### Deploy an inlets Pro TCP client
 
 * [Run an inlets PRO client in your Kubernetes cluster](https://github.com/inlets/inlets-pro/tree/master/chart/inlets-pro-client)
 
-### Deploy an inlets PRO HTTP client or server
+### Deploy an inlets Pro HTTP client or server
 
 To deploy a client or server, request access to the helm chart after your purchase.
 

--- a/chart/inlets-http-server/templates/control-plane-ingress.yaml
+++ b/chart/inlets-http-server/templates/control-plane-ingress.yaml
@@ -1,9 +1,5 @@
 {{- $fullName := include "inlets-http-server.fullname" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,6 +19,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "inlets-http-server.fullname" . }}
-              servicePort: {{ .Values.controlPlane.port }}
+              service:
+                name: {{ include "inlets-http-server.fullname" . }}
+                port:
+                  number: {{ .Values.controlPlane.port }}

--- a/chart/inlets-http-server/templates/data-plane-ingress.yaml
+++ b/chart/inlets-http-server/templates/data-plane-ingress.yaml
@@ -2,11 +2,7 @@
 
 {{- range $name, $data := .Values.dataPlaneIngresses }}
 {{- $fullName := include "inlets-http-server.fullname" $top -}}
-{{- if semverCompare ">=1.14-0" $top.Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-{{ $name }}
@@ -26,8 +22,11 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "inlets-http-server.fullname" $top }}
-              servicePort: {{ $top.Values.dataPlane.port }}
+              service:
+                name: {{ include "inlets-http-server.fullname" $top }}
+                port:
+                  number: {{ $top.Values.dataPlane.port }}
 ---
 {{- end }}

--- a/chart/inlets-pro/templates/ingress.yaml
+++ b/chart/inlets-pro/templates/ingress.yaml
@@ -1,10 +1,6 @@
 {{- $fullName := include "inlets-pro.fullname" . -}}
 {{- $tlsSecretName := include "inlets-pro.tlsSecretName" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -24,6 +20,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "inlets-pro.fullname" . }}-control-plane
-              servicePort: {{ .Values.controlPlane.port }}
+              service:
+                name: {{ include "inlets-pro.fullname" . }}-control-plane
+                port:
+                  number: {{ .Values.controlPlane.port }}


### PR DESCRIPTION
In K8s v1.22 the networking.k8s.io/v1beta API has been removed
so this commit migrates to charts to networking.k8s.io/v1

Going forward K8s 1.19 will be a minimum requirement.

Fixes: #38

Tested by running: `helm template chart/inlets-pro | kubectl apply -f -` and seeing a valid ingress object created against a local KinD cluster running v1.24 and helm v3.9.2

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>