### PR TITLE
Sync missing GHCR images

### DIFF
--- a/.github/workflows/sync-images.yml
+++ b/.github/workflows/sync-images.yml
@@ -1,0 +1,42 @@
+name: sync-images
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Sync a single tag. Leave empty to sync all missing tags."
+        required: false
+        type: string
+  schedule:
+    - cron: "17 2 * * *"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  sync-images:
+    name: Sync missing images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup arkade
+        uses: alexellis/arkade-get@master
+        with:
+          crane: v0.21.7
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ github.token }}" | crane auth login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Sync images
+        env:
+          SOURCE_IMAGE: ghcr.io/openfaasltd/inlets-pro
+          TARGET_IMAGE: ghcr.io/inlets/inlets-pro
+          TAG: ${{ inputs.tag }}
+        run: ./hack/sync-images.sh "${SOURCE_IMAGE}" "${TARGET_IMAGE}" "${TAG}" >> "${GITHUB_STEP_SUMMARY}"

--- a/hack/sync-images.sh
+++ b/hack/sync-images.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <source-image> <target-image> [tag]" >&2
+  echo "Example: $0 ghcr.io/openfaasltd/inlets-pro ghcr.io/inlets/inlets-pro 0.11.13" >&2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  usage
+  exit 1
+fi
+
+source_image="$1"
+target_image="$2"
+tag="${3:-}"
+
+if [ -n "${tag}" ]; then
+  source_tags="${tag}"
+else
+  source_tags="$(crane ls "${source_image}" | sort -V)"
+fi
+
+target_tags_err="$(mktemp)"
+trap 'rm -f "${target_tags_err}"' EXIT
+
+if target_tags="$(crane ls "${target_image}" 2>"${target_tags_err}" | sort -V)"; then
+  :
+elif grep -q "NAME_UNKNOWN" "${target_tags_err}"; then
+  target_tags=""
+else
+  cat "${target_tags_err}" >&2
+  exit 1
+fi
+
+copied=0
+skipped=0
+
+echo "### Image sync"
+echo
+echo "| Tag | Result |"
+echo "| --- | --- |"
+
+for source_tag in ${source_tags}; do
+  if echo "${target_tags}" | grep -Fxq "${source_tag}"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  crane cp "${source_image}:${source_tag}" "${target_image}:${source_tag}" >&2
+  echo "| \`${source_tag}\` | Copied |"
+  copied=$((copied + 1))
+done
+
+echo
+echo "Copied: ${copied}"
+echo "Skipped: ${skipped}"


### PR DESCRIPTION
## Description

Adds a `sync-images` workflow that copies missing image tags from `ghcr.io/openfaasltd/inlets-pro` to `ghcr.io/inlets/inlets-pro`. It runs nightly and can also be started manually.

The workflow uses `crane ls` to compare source and target tags, skips tags already present in the public package, copies only missing tags with `crane cp`, and writes copied tags plus an aggregate skipped count to the workflow summary. The source package is expected to be public; the workflow uses the repository `GITHUB_TOKEN` with `packages: write` to publish to the public package.

**Manual sync**

Run the workflow from GitHub Actions and set `tag` to a version, for example `0.11.14`. This copies `ghcr.io/openfaasltd/inlets-pro:0.11.14` to `ghcr.io/inlets/inlets-pro:0.11.14` if it is missing. If the tag is already present, it is skipped and included in the skipped count. Leave `tag` empty to sync all missing tags.

## Motivation and context

This is part of a series of changes to automate release publishing from the private inlets-pro repo and syncing those releases to the public inlets-pro repo.

## How has this been tested

- Dry-ran the sync logic locally with the public package as both source and target and an existing tag.
- Tested the workflow end-to-end in a separate organization by syncing a public test image tag to a new GHCR package and verifying that the copied target image digest matched the source image digest.
